### PR TITLE
Make off time exclusive

### DIFF
--- a/index.js
+++ b/index.js
@@ -146,7 +146,7 @@ module.exports = function (RED) {
             const now = this.now();
             const { start, end } = calculateStartAndEnd(now);
             const range = Moment.range(start, end);
-            const output = range.contains(now) ? 1 : 2;
+            const output = range.contains(now, { excludeEnd: true; }) ? 1 : 2;
             const msgs = [];
             msgs[output - 1] = msg;
             this.send(msgs);


### PR DESCRIPTION
When a user says "Turn lights on at 8PM, off at 10PM", they usually mean that at 8:00:00 PM the lights turn on, and at 10:00:00 PM the lights turn off. Hence, the range is meant inclusively of the on time, and exclusively of the off time. This patch implements this behavior.